### PR TITLE
Store and Restore Previous Window Size, Avoid Fullscreen on Start.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ const createMainWindow = async () => {
 		minHeight: 800,
 		titleBarStyle: "hidden",
 		fullscreenable: true,
-		fullscreen: true,
+		fullscreen: false,
 		frame: os.platform() == "linux" ? false : true,
 		icon: path.join(__dirname, "static/logo.png"),
 		webPreferences: {

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const { is } = require("electron-util");
 const unhandled = require("electron-unhandled");
 const debug = require("electron-debug");
 const contextMenu = require("electron-context-menu");
+const config = require('./config');
 const menu = require("./menu");
 
 if (os.platform() == "darwin") {
@@ -32,16 +33,17 @@ app.commandLine.appendSwitch("ignore-certificate-errors");
 let mainWindow;
 
 const createMainWindow = async () => {
+	const ws = config.get('windowstate', {});
 	const win = new BrowserWindow({
 		title: "Clubhouse Desktop Client",
 		show: false,
-		width: 1020,
-		height: 800,
+		width: ws.width || 1020,
+		height: ws.height || 800,
 		minWidth: 1360,
 		minHeight: 800,
 		titleBarStyle: "hidden",
 		fullscreenable: true,
-		fullscreen: false,
+		isMaximized: ws.isMaximized,
 		frame: os.platform() == "linux" ? false : true,
 		icon: path.join(__dirname, "static/logo.png"),
 		webPreferences: {
@@ -70,6 +72,17 @@ const createMainWindow = async () => {
 		// Dereference the window
 		// For multiple windows store them in an array
 		mainWindow = undefined;
+	});
+
+	win.on("close", () => {
+		const isMaximized = win.isMaximized();
+		const bounds = win.getBounds();
+		
+		config.set('windowstate', {
+			height: bounds.height,
+			width: bounds.width,
+			isMaximized: isMaximized
+		});
 	});
 
 	await win.loadFile(path.join(__dirname, "index.html"));


### PR DESCRIPTION
Right now, app starts with fullscreen mode, which is
a bad UX. If user wants, they still can make it fullscreen once
the app is loaded.

Removing these variables makes the window system to remember and
re-store previous size.

Fixes https://github.com/callmearta/clubhouse-desktop/issues/17