### PR TITLE
use high quality audio

### DIFF
--- a/app/views/channel.js
+++ b/app/views/channel.js
@@ -448,6 +448,7 @@ const Channel = {
 								await navigator.mediaDevices.enumerateDevices()
 							).filter(i => i.kind == "audioinput")[0].deviceId
 						});
+						stream.setAudioProfile('high_quality_stereo');
 						stream.init(() => {
 							if (client) {
 								stream.enableAudio();


### PR DESCRIPTION
`high_quality` without stereo can also be used. But I couldn't clearly notice any difference.

I tried setting up it as a run-time option, but I guess either you'll
have to restart the application or exit a group and re-join. So for now,
setting this as default.

Fixes https://github.com/callmearta/clubhouse-desktop/issues/16