### PR TITLE
Point version of clubhouse-api to new commit and fix notifications error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2620,7 +2620,7 @@
 			}
 		},
 		"clubhouse-api": {
-			"version": "git+ssh://git@github.com/callmearta/clubhouse-api.git#78f7222465d3749de2d12ac3aa955883f4e608d1",
+			"version": "git+ssh://git@github.com/callmearta/clubhouse-api.git#acac75f078092f334b71220674bf7513ec3e51e5",
 			"from": "clubhouse-api@git+https://github.com/callmearta/clubhouse-api.git",
 			"requires": {
 				"cross-fetch": "^3.0.6",


### PR DESCRIPTION
Hi,
     This pull request is for solving #47 which is related to notifications. I found that it is due to that the package-lock.json is pointing to an older commit of clubhouse-api repository. After that commit, I found that you've changed API endpoint of getNotifications from /follow to /get_notifications. So I've changed the commit ID of clubhouse-api module in package-lock.json to the latest commit. Hope this will fix all errors related to notifications.
Thanks,
Vivek K J