### PR TITLE
Fix Instagram nickname visibility in darkmode and Add a home button to channels/rooms 

### DIFF
--- a/app/views/channel.js
+++ b/app/views/channel.js
@@ -1032,6 +1032,9 @@ const Channel = {
                 <div class="d-flex align-items-center justify-content-between px-4 pt-4">
                     <h1 class="h4 overflow-ellipsis">{{channel.topic}}</h1>
                     <div class="d-flex align-items-center justify-content-end">
+						<button class="btn-light mr-3" @click="$router.replace('/')">
+						    <i class="far fa-home cursor-pointer" ></i>
+						</button>
                         <button class="btn-light mr-3" @click="handRaise" v-if="!isSpeaker && channel.handraise_permission">
                             <img :src="this.handRaised ? 'assets/images/fist.png' : 'assets/images/handraise.png'" height="18" />
                         </button>

--- a/app/views/user.js
+++ b/app/views/user.js
@@ -389,11 +389,11 @@ const User = {
                         </router-link>
                     </div>
                     <div class="d-flex align-items-center justify-content-start border-top mt-2 pt-3 w-100">
-                        <a :href="'https://instagram.com/' + user.user_profile.instagram" title="" target="_blank" class="text-dark mr-3" v-if="user.user_profile.instagram">
+                        <a :href="'https://instagram.com/' + user.user_profile.instagram" title="" target="_blank" class="text-primary mr-3" v-if="user.user_profile.instagram">
                             <i class="fab fa-instagram"></i>
                             <span>{{user.user_profile.instagram}}</span>
                         </a>
-                        <a :href="'https://twitter.com/' + user.user_profile.twitter" title="" target="_blank" class="text-dark" v-if="user.user_profile.twitter">
+                        <a :href="'https://twitter.com/' + user.user_profile.twitter" title="" target="_blank" class="text-primary" v-if="user.user_profile.twitter">
                             <i class="fab fa-twitter"></i>
                             <span>{{user.user_profile.twitter}}</span>
                         </a>


### PR DESCRIPTION
This PR handles two of the issues mentioned in  #33 

- Fixes the instagram/twitter username visibility issue in dark mode 
- Adds a home button in channels/rooms so that user can easily navigate to home without exiting from the room